### PR TITLE
Feat: Add permExactMatchTrigger Lua function

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5234,6 +5234,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "appendLog", TLuaInterpreter::appendLog);
     lua_register(pGlobalLua, "calcFontSize", TLuaInterpreter::calcFontSize);
     lua_register(pGlobalLua, "permRegexTrigger", TLuaInterpreter::permRegexTrigger);
+    lua_register(pGlobalLua, "permExactMatchTrigger", TLuaInterpreter::permExactMatchTrigger);
     lua_register(pGlobalLua, "permSubstringTrigger", TLuaInterpreter::permSubstringTrigger);
     lua_register(pGlobalLua, "permBeginOfLineStringTrigger", TLuaInterpreter::permBeginOfLineStringTrigger);
     lua_register(pGlobalLua, "tempComplexRegexTrigger", TLuaInterpreter::tempComplexRegexTrigger);
@@ -6416,6 +6417,33 @@ std::pair<int, QString> TLuaInterpreter::startPermRegexTrigger(const QString& na
     }
     if (parent.isEmpty()) {
         pT = new TTrigger("a", patterns, propertyList, (patterns.size() > 1), mpHost);
+    } else {
+        TTrigger* pP = mpHost->getTriggerUnit()->findTrigger(parent);
+        if (!pP) {
+            return std::pair(-1, qsl("parent '%1' not found").arg(parent));
+        }
+        pT = new TTrigger(pP, mpHost);
+        pT->setRegexCodeList(patterns, propertyList);
+    }
+    pT->setIsFolder(patterns.empty());
+    pT->setIsActive(true);
+    pT->setTemporary(false);
+    pT->registerTrigger();
+    pT->setScript(function);
+    pT->setName(name);
+    updateEditor();
+    return std::pair(pT->getID(), QString());
+}
+
+// No documentation available in wiki - internal function
+std::pair<int, QString> TLuaInterpreter::startPermExactMatchTrigger(const QString& name, const QString& parent, const QString& exactLine, const QString& function)
+{
+    TTrigger* pT;
+    QStringList patterns{ exactLine };
+    QList<int> propertyList{ REGEX_EXACT_MATCH };
+
+    if (parent.isEmpty()) {
+        pT = new TTrigger("a", patterns, propertyList, false, mpHost);
     } else {
         TTrigger* pP = mpHost->getTriggerUnit()->findTrigger(parent);
         if (!pP) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6436,11 +6436,13 @@ std::pair<int, QString> TLuaInterpreter::startPermRegexTrigger(const QString& na
 }
 
 // No documentation available in wiki - internal function
-std::pair<int, QString> TLuaInterpreter::startPermExactMatchTrigger(const QString& name, const QString& parent, const QString& exactLine, const QString& function)
+std::pair<int, QString> TLuaInterpreter::startPermExactMatchTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function)
 {
     TTrigger* pT;
-    QStringList patterns{ exactLine };
     QList<int> propertyList{ REGEX_EXACT_MATCH };
+    for (int i = 0; i < patterns.size(); i++) {
+        propertyList << REGEX_EXACT_MATCH;
+    }
 
     if (parent.isEmpty()) {
         pT = new TTrigger("a", patterns, propertyList, false, mpHost);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -161,6 +161,7 @@ public:
     int startTempColorTrigger(int, int, const QString&, int expiryCount = -1);
     int startTempPromptTrigger(const QString& function, int expiryCount = -1);
     std::pair<int, QString> startPermRegexTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function);
+    std::pair<int, QString> startPermExactMatchTrigger(const QString& name, const QString& parent, const QString& exactLine, const QString& function);
     std::pair<int, QString> startPermSubstringTrigger(const QString& name, const QString& parent, const QStringList& patterns, const QString& function);
     std::pair<int, QString> startPermBeginOfLineStringTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function);
     std::pair<int, QString> startPermPromptTrigger(const QString& name, const QString& parent, const QString& function);
@@ -526,6 +527,7 @@ public:
     static int calcFontHeight(int size);
     static int calcFontSize(lua_State*);
     static int permRegexTrigger(lua_State*);
+    static int permExactMatchTrigger(lua_State*);
     static int permSubstringTrigger(lua_State*);
     static int permTimer(lua_State*);
     static int permScript(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -161,7 +161,7 @@ public:
     int startTempColorTrigger(int, int, const QString&, int expiryCount = -1);
     int startTempPromptTrigger(const QString& function, int expiryCount = -1);
     std::pair<int, QString> startPermRegexTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function);
-    std::pair<int, QString> startPermExactMatchTrigger(const QString& name, const QString& parent, const QString& exactLine, const QString& function);
+    std::pair<int, QString> startPermExactMatchTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function);
     std::pair<int, QString> startPermSubstringTrigger(const QString& name, const QString& parent, const QStringList& patterns, const QString& function);
     std::pair<int, QString> startPermBeginOfLineStringTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function);
     std::pair<int, QString> startPermPromptTrigger(const QString& name, const QString& parent, const QString& function);

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1139,7 +1139,22 @@ int TLuaInterpreter::permExactMatchTrigger(lua_State* L)
 {
     const QString name = getVerifiedString(L, __func__, 1, "trigger name");
     const QString parent = getVerifiedString(L, __func__, 2, "trigger parent");
-    const QString exactMatchPattern = getVerifiedString(L, __func__, 3, "exact match pattern");
+
+    QStringList exactMatchList;
+    if (!lua_istable(L, 3)) {
+        lua_pushfstring(L, "permExactMatchTrigger: bad argument #3 type (sub-strings list as table expected, got %s!)",
+                        luaL_typename(L, 3));
+        return lua_error(L);
+    }
+    lua_pushnil(L);
+    while (lua_next(L, 3) != 0) {
+        // key at index -2 and value at index -1
+        if (lua_type(L, -1) == LUA_TSTRING) {
+            exactMatchList << lua_tostring(L, -1);
+        }
+        // removes value, but keeps key for next iteration
+        lua_pop(L, 1);
+    }
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -1149,7 +1164,7 @@ int TLuaInterpreter::permExactMatchTrigger(lua_State* L)
     }
 
     const QString script{lua_tostring(L, 4)};
-    auto [triggerId, message] = pLuaInterpreter->startPermExactMatchTrigger(name, parent, exactMatchPattern, script);
+    auto [triggerId, message] = pLuaInterpreter->startPermExactMatchTrigger(name, parent, exactMatchList, script);
     if (triggerId == -1) {
         lua_pushfstring(L, "permExactMatchTrigger: cannot create trigger (%s)", message.toUtf8().constData());
         return lua_error(L);

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1134,6 +1134,30 @@ int TLuaInterpreter::permRegexTrigger(lua_State* L)
     return 1;
 }
 
+// Documentation: TODO (https://wiki.mudlet.org/w/Manual:Lua_Functions#permExactMatchTrigger)
+int TLuaInterpreter::permExactMatchTrigger(lua_State* L)
+{
+    const QString name = getVerifiedString(L, __func__, 1, "trigger name");
+    const QString parent = getVerifiedString(L, __func__, 2, "trigger parent");
+    const QString exactMatchPattern = getVerifiedString(L, __func__, 3, "exact match pattern");
+
+    Host& host = getHostFromLua(L);
+    TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
+    if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(4); !validationResult) {
+        lua_pushfstring(L, "permExactMatchTrigger: bad argument #%d (%s)", 4, validationMessage.toUtf8().constData());
+        return lua_error(L);
+    }
+
+    const QString script{lua_tostring(L, 4)};
+    auto [triggerId, message] = pLuaInterpreter->startPermExactMatchTrigger(name, parent, exactMatchPattern, script);
+    if (triggerId == -1) {
+        lua_pushfstring(L, "permExactMatchTrigger: cannot create trigger (%s)", message.toUtf8().constData());
+        return lua_error(L);
+    }
+    lua_pushnumber(L, triggerId);
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permBeginOfLineStringTrigger
 int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
 {

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -342,6 +342,7 @@
     "pauseSpeedwalk": "pauseSpeedwalk()",
     "permAlias": "permAlias(name, parent, regex, lua code)",
     "permBeginOfLineStringTrigger": "permBeginOfLineStringTrigger(name, parent, pattern table, lua code)",
+    "permExactMatchTrigger": "permExactMatchTrigger(name, parent, exact line, lua code)",
     "permGroup": "permGroup(name, itemtype, [parent])",
     "permKey": "permKey(name, parent, [modifier], key code, lua code)",
     "permPromptTrigger": "permPromptTrigger(name, parent, lua code)",

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -342,7 +342,7 @@
     "pauseSpeedwalk": "pauseSpeedwalk()",
     "permAlias": "permAlias(name, parent, regex, lua code)",
     "permBeginOfLineStringTrigger": "permBeginOfLineStringTrigger(name, parent, pattern table, lua code)",
-    "permExactMatchTrigger": "permExactMatchTrigger(name, parent, exact line, lua code)",
+    "permExactMatchTrigger": "permExactMatchTrigger(name, parent, exact lines table, lua code)",
     "permGroup": "permGroup(name, itemtype, [parent])",
     "permKey": "permKey(name, parent, [modifier], key code, lua code)",
     "permPromptTrigger": "permPromptTrigger(name, parent, lua code)",


### PR DESCRIPTION
Closes #2 

This PR adds a new Lua function called `permExactMatchTrigger` which creates a permanent trigger with a single exact match pattern.
