### PR TITLE
Infrastructure: Auto-label issues and improve bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug to help improve Mudlet
 title: ''
-labels: ['']
+labels: ['triage']
 assignees: ''
 type: 'bug'
 

--- a/.github/ISSUE_TEMPLATE/01-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.md
@@ -17,7 +17,12 @@ type: 'bug'
 2. 
 3. 
 
+#### Mudlet version and operating system:
+
+- **Mudlet version:** 
+- **Operating system:** 
+
 #### Error output
 
 
-#### Extra information, such as the Mudlet version, operating system and ideas for how to solve:
+#### Extra information, such as ideas for how to solve:

--- a/.github/ISSUE_TEMPLATE/02-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Submit an idea to improve Mudlet
 title: ''
-labels: ''
+labels: ['triage']
 assignees: ''
 type: 'feature'
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Added "triage" label to all new issues by default
- Updated bug report template to prominently request OS and Mudlet version

#### Motivation for adding to Mudlet
1. **Triage workflow**: All new issues are automatically marked with a `triage` label, making it easy for volunteers to filter and review issues that need initial classification.
2. **Better bug reports**: The bug report template now explicitly asks for Mudlet version and operating system in a dedicated section, ensuring reporters provide this critical information upfront.

#### Other info (issues closed, discussion etc)
Attempts to close #10 