### PR TITLE
Add: Allow default deleted profiles to be restored

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -835,6 +835,33 @@ void dlgConnectionProfiles::reallyDeleteProfile(const QString& profile)
     listWidget_profiles->setFocus();
 }
 
+QStringList dlgConnectionProfiles::getDeletedDefaults() const
+{
+    auto& settings = *mudlet::self()->mpSettings;
+    return settings.value(qsl("deletedDefaultMuds"), QStringList()).toStringList();
+}
+
+void dlgConnectionProfiles::slot_restoreDefaultProfile(const QString& profile)
+{
+    auto& settings = *mudlet::self()->mpSettings;
+    auto deletedDefaultMuds = getDeletedDefaults();
+
+    if(!deletedDefaultMuds.contains(profile))
+        return;
+
+    deletedDefaultMuds.removeAll(profile);
+    settings.setValue(qsl("deletedDefaultMuds"), deletedDefaultMuds);
+
+    fillout_form();
+}
+
+void dlgConnectionProfiles::slot_restoreAllDefaults()
+{
+    auto& settings = *mudlet::self()->mpSettings;
+    settings.setValue(qsl("deletedDefaultMuds"), QStringList());
+    fillout_form();
+}
+
 // called when the 'delete' button is pressed, raises a dialog to confirm deletion
 // if this profile has been used
 void dlgConnectionProfiles::slot_deleteProfile()

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -50,6 +50,7 @@ public:
     QList<QListWidgetItem*> findData(const QListWidget& listWidget, const QVariant& what, const int role = Qt::UserRole) const;
     QList<int> findProfilesBeginningWith(const QString&) const;
     static const int csmNameRole{Qt::UserRole};
+    QStringList getDeletedDefaults() const;
 
     QString btn_connect_enabled_accessDesc;
     QString btn_load_enabled_accessDesc;
@@ -76,6 +77,8 @@ public slots:
     void slot_addProfile();
     void slot_deleteProfile();
     void slot_reallyDeleteProfile();
+    void slot_restoreDefaultProfile(const QString& profile);
+    void slot_restoreAllDefaults();
 
     void slot_updateAutoConnect(int state);
     void slot_updateAutoReconnect(int state);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -239,6 +239,7 @@ void mudlet::init()
     menuHelp->setToolTipsVisible(true);
     menuAbout->setToolTipsVisible(true);
 
+    setupRestoreDefaultsMenu();
     setAttribute(Qt::WA_DeleteOnClose);
     const QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setWindowTitle(scmVersion);
@@ -3219,6 +3220,53 @@ void mudlet::restoreProfileFocus(const QString& profileName)
                 }
             }
         }
+    });
+}
+
+void mudlet::setupRestoreDefaultsMenu()
+{
+    auto restoreDefaultsMenu = menuGames->addMenu(tr("Restore Default Profiles"));
+    connect(restoreDefaultsMenu, &QMenu::aboutToShow, this, [this, restoreDefaultsMenu]() {
+        // Ensure no previous entries exist to avoid duplicates
+        restoreDefaultsMenu->clear();
+        mpSettings->sync(); 
+        QStringList deleted = mpSettings->value(qsl("deletedDefaultMuds"), QStringList()).toStringList();
+        for (const auto& game : TGameDetails::scmDefaultGames) {
+            if (deleted.contains(game.name)) {
+                QAction* restore = new QAction(game.name, restoreDefaultsMenu);
+                connect(restore, &QAction::triggered, this, [this, game]() {
+                    auto* dlg = findChild<dlgConnectionProfiles*>();
+                    // Open dialog if not open
+                    if (!dlg) {
+                        slot_showConnectionDialog();
+                        dlg = findChild<dlgConnectionProfiles*>();
+                    }
+                    // Restore specific deleted game
+                    if (dlg) {
+                        dlg->slot_restoreDefaultProfile(game.name);
+                    }
+                });
+                restoreDefaultsMenu->addAction(restore);
+            }
+        }
+
+        if (!deleted.isEmpty()) {
+            restoreDefaultsMenu->addSeparator();
+            QAction* restoreAll = new QAction(tr("Restore All Defaults"), restoreDefaultsMenu);
+            connect(restoreAll, &QAction::triggered, this, [this]() {
+                auto* dlg = findChild<dlgConnectionProfiles*>();
+                if (!dlg) {
+                    slot_showConnectionDialog();
+                    dlg = findChild<dlgConnectionProfiles*>();
+                }
+                // Restore all default games
+                if (dlg) {
+                    dlg->slot_restoreAllDefaults();
+                }
+            });
+            restoreDefaultsMenu->addAction(restoreAll); 
+        }
+        restoreDefaultsMenu->setEnabled(true);
     });
 }
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -568,6 +568,7 @@ private:
     bool scanDictionaryFile(const QString& dictionaryPath, int&, QHash<QString, unsigned int>&, QStringList&);
     int scanWordList(QStringList&, QHash<QString, unsigned int>&);
     void setupTrayIcon();
+    void setupRestoreDefaultsMenu();
     void reshowRequiredMainConsoles();
     void toggleMute(bool state, QAction* toolbarAction, QAction* menuAction, bool isAPINotGame, const QString& unmuteText, const QString& muteText);
     dlgTriggerEditor* createMudletEditor();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Allows safely restoring deleted default profiles
- Restricts deletedDefaultMuds to only record default games and not 
user created profiles.

#### Motivation for adding to Mudlet
Many times users might accidentally delete a default profile as they don't ask for checks before deleting,
adding this button can allow them to simply restore default profiles.

#### Other info (issues closed, discussion etc)
Attempts to close #7 