### PR TITLE
Feat: Allow adding and deleting areas via GUI

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,7 @@ set(mudlet_SRCS
     dlgAliasMainArea.cpp
     dlgColorTrigger.cpp
     dlgComposer.cpp
+    dlgConfigureAreas.cpp
     dlgConnectionProfiles.cpp
     dlgIRC.cpp
     dlgKeysMainArea.cpp
@@ -232,6 +233,7 @@ set(mudlet_UIS
     ui/aliases_main_area.ui
     ui/color_trigger.ui
     ui/composer.ui
+    ui/configure_areas.ui
     ui/connection_profiles.ui
     ui/dlgPackageExporter.ui
     ui/irc.ui

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3320,6 +3320,7 @@ void T2DMap::slot_createRoom()
     isCenterViewCall = true;
     mpMap->updateArea(mAreaID);
     isCenterViewCall = false;
+    emit mpMap->signal_roomsChanged();
     mpMap->setUnsaved(__func__);
 }
 
@@ -4106,6 +4107,7 @@ void T2DMap::slot_deleteRoom()
     mMultiSelectionListWidget.clear();
     mMultiSelectionListWidget.hide();
     repaint();
+    emit mpMap->signal_roomsChanged();
     mpMap->setUnsaved(__func__);
 }
 

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -76,6 +76,7 @@ class TMap : public QObject
 signals:
     void signal_saveErrorChanged(bool hasError);
     void signal_areaChanged(int areaId);
+    void signal_roomsChanged();
 
 private:
     QString mDefaultAreaName;

--- a/src/dlgConfigureAreas.cpp
+++ b/src/dlgConfigureAreas.cpp
@@ -23,13 +23,8 @@
 
 #include "mudlet.h"
 
-#include <QElapsedTimer>
 #include <QInputDialog>
-#include <QListWidget>
-#include <QMenu>
 #include <QMessageBox>
-#include <QPainter>
-#include <QProgressDialog>
 
 enum Columns 
 {
@@ -46,12 +41,13 @@ dlgConfigureAreas::dlgConfigureAreas(TMap* map, QWidget* parent) : QDialog(paren
     areaTable->setSelectionMode(QAbstractItemView::SingleSelection);
 
     setWindowTitle(tr("Configure Areas"));
-    resize(400, 300);
 
-    areaTable->setColumnCount(ColCount);
-    areaTable->setColumnHidden(ColAreaId, true);
-
-    areaTable->setHorizontalHeaderLabels({tr("Area Name"), QString(), tr("Rooms")});
+    areaTable->setColumnCount(3);
+    areaTable->setHorizontalHeaderLabels({tr("Area Name"), tr("Area ID"), tr("Rooms")});
+    areaTable->setColumnHidden(1, true);
+    areaTable->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    areaTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    areaTable->horizontalHeader()->setStretchLastSection(true);
 
     connect(addAreaBtn, &QPushButton::clicked, this, &dlgConfigureAreas::slot_addArea);
     connect(removeAreaBtn, &QPushButton::clicked, this, &dlgConfigureAreas::slot_removeArea);
@@ -59,64 +55,56 @@ dlgConfigureAreas::dlgConfigureAreas(TMap* map, QWidget* parent) : QDialog(paren
     populateAreaList();
 }
 
-bool checkDefaultArea(TMap* map, int areaId)
-{
-    if (!map || !map->mpRoomDB) 
-    {
-        return false;
-    }
-
-    const QString defaultAreaName = map->getDefaultAreaName();
-    const auto& areaNames = map->mpRoomDB->getAreaNamesMap();
-
-    return areaNames.value(areaId) == defaultAreaName;
-}
-
 int dlgConfigureAreas::currentAreaId() const
 {
     const auto selected = areaTable->selectionModel()->selectedRows();
-    if (selected.isEmpty()) 
-    {
+    if (selected.isEmpty()) {
         return -1;
     }
 
     return areaTable->item(selected.first().row(), ColAreaId)->text().toInt();
 }
 
-void dlgConfigureAreas::refreshAreas()
+void dlgConfigureAreas::refreshAreas(bool added, const QString& areaName)
 {
-    QWidget* p = parentWidget();
-    while (p) 
-    {
-        const auto mappers = p->findChildren<dlgMapper*>();
-        for (dlgMapper* mapper : mappers) 
-        {
-            mapper->updateAreaComboBox();
-        }
-        p = p->parentWidget();
+    if(!mpMap || !mpMap->mpMapper)
+        return;
+
+    auto mapper = mpMap->mpMapper;
+    mapper->updateAreaComboBox();
+    QComboBox* combo = mapper->findChild<QComboBox*>();
+
+    QString targetArea;
+    if(added) {
+        targetArea = areaName;
     }
+    else {
+        targetArea = mpMap->getDefaultAreaName();
+    }
+
+    const int index = combo->findText(targetArea);
+    if(index >= 0) {
+        mapper->slot_switchArea(index);
+        combo->setCurrentIndex(index);
+    }
+
+    mpMap->setUnsaved(__func__);
 }
 
 void dlgConfigureAreas::populateAreaList()
 {
-    if (!mpMap || !mpMap->mpRoomDB) 
-    {
+    if (!mpMap || !mpMap->mpRoomDB) {
         return;
     }
 
     areaTable->setRowCount(0);
-
     const auto& areaNames = mpMap->mpRoomDB->getAreaNamesMap();
-
     int row = 0;
-    for (auto it = areaNames.begin(); it != areaNames.end(); ++it) 
-    {
+    for (auto it = areaNames.begin(); it != areaNames.end(); ++it) {
         const int areaId = it.key();
         const QString& areaName = it.value();
-
         int roomCount = 0;
-        if (TArea* area = mpMap->mpRoomDB->getArea(areaId)) 
-        {
+        if (TArea* area = mpMap->mpRoomDB->getArea(areaId)) {
             roomCount = area->getAreaRooms().size();
         }
 
@@ -132,71 +120,57 @@ void dlgConfigureAreas::populateAreaList()
 
 void dlgConfigureAreas::slot_addArea()
 {
-    if (!mpMap || !mpMap->mpRoomDB)
-    {
+    if (!mpMap || !mpMap->mpRoomDB) {
         return;
     }
 
     bool ok{};
-    const QString name = QInputDialog::getText(this, tr("Add Area:"), tr("Area Name"), QLineEdit::Normal, QString(), &ok);
-
-    if (!ok || name.trimmed().isEmpty()) 
-    {
+    const QString rawName = QInputDialog::getText(this, tr("Add Area:"), tr("Area Name"), QLineEdit::Normal, QString(), &ok);
+    const QString name = rawName.trimmed();
+    if (!ok || name.isEmpty()) {
         return;
     }
 
-    const int newId = mpMap->mpRoomDB->addArea(name);
-    if (newId <= 0) 
-    {
-        QMessageBox::warning(this, tr("Cannot add area"), tr("Area with this name already exists."));
+    if (mpMap->mpRoomDB->getAreaNamesMap().values().count(name) > 0) {
+        statusLabel->setText(tr("Area with this name already exists."));
         return;
     }
+
+    mpMap->mpRoomDB->addArea(name);
+    statusLabel->clear();
 
     populateAreaList();
-    refreshAreas();
+    refreshAreas(true, name);
 }
 
 void dlgConfigureAreas::slot_removeArea()
 {
-    if (!mpMap || !mpMap->mpRoomDB) 
-    {
+    if (!mpMap || !mpMap->mpRoomDB) {
         return;
     }
 
     const int areaId = currentAreaId();
-    if (areaId <= 0) 
-    {
-        return;
-    }
-
-    if (checkDefaultArea(mpMap, areaId)) 
-    {
-        QMessageBox::warning(this, tr("Cannot delete area"), tr("Default area cannot be deleted."));
+    if (areaId == -1) {
+        statusLabel->setText(tr("Default area cannot be deleted."));
         return;
     }
 
     TArea* area = mpMap->mpRoomDB->getArea(areaId);
     const int roomCount = area ? area->getAreaRooms().size() : 0;
+    if (roomCount > 0) {
+        const auto reply = QMessageBox::warning(this, tr("Delete area"), tr("This will also delete %1 rooms.\nDo you want to continue?").arg(roomCount),
+                           QMessageBox::Yes | QMessageBox::No,
+                           QMessageBox::No);
 
-    if (roomCount > 0) 
-    {
-        QMessageBox::warning(this, tr("Cannot delete area"), tr("This area contains %1 rooms.\n"
-               "Move or delete the rooms first.").arg(roomCount));
-        return;
-    }
-
-    const QString areaName = mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
-
-    const auto ret = QMessageBox::warning(this, tr("Delete Area"), tr("Delete empty area \"%1\"?").arg(areaName),
-                                        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
-
-    if (ret != QMessageBox::Yes) 
-    {
-        return;
+        if (reply != QMessageBox::Yes) {
+            return;
+        }
     }
 
     mpMap->mpRoomDB->removeArea(areaId);
+    statusLabel->clear();
 
     populateAreaList();
-    refreshAreas();
+    refreshAreas(false, QString());
 }
+

--- a/src/dlgConfigureAreas.cpp
+++ b/src/dlgConfigureAreas.cpp
@@ -117,8 +117,6 @@ void dlgConfigureAreas::populateAreaList()
         areaTable->setItem(row, ColRoomCount, new QTableWidgetItem(QString::number(roomCount)));
         ++row;
     }
-
-    areaTable->resizeColumnsToContents();
 }
 
 void dlgConfigureAreas::slot_addArea()

--- a/src/dlgConfigureAreas.cpp
+++ b/src/dlgConfigureAreas.cpp
@@ -37,6 +37,9 @@ enum Columns
 dlgConfigureAreas::dlgConfigureAreas(TMap* map, QWidget* parent) : QDialog(parent), mpMap(map)
 {
     setupUi(this);
+    if(mpMap) {
+        connect(mpMap, &TMap::signal_roomsChanged, this, &dlgConfigureAreas::populateAreaList);
+    }
     areaTable->setSelectionBehavior(QAbstractItemView::SelectRows);
     areaTable->setSelectionMode(QAbstractItemView::SingleSelection);
 

--- a/src/dlgConfigureAreas.cpp
+++ b/src/dlgConfigureAreas.cpp
@@ -1,0 +1,202 @@
+/***************************************************************************
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "dlgConfigureAreas.h"
+#include "dlgMapper.h"
+#include "TArea.h"
+#include "TMap.h"
+#include "TRoomDB.h"
+
+#include "mudlet.h"
+
+#include <QElapsedTimer>
+#include <QInputDialog>
+#include <QListWidget>
+#include <QMenu>
+#include <QMessageBox>
+#include <QPainter>
+#include <QProgressDialog>
+
+enum Columns 
+{
+    ColAreaName = 0,
+    ColAreaId,
+    ColRoomCount,
+    ColCount
+};
+
+dlgConfigureAreas::dlgConfigureAreas(TMap* map, QWidget* parent) : QDialog(parent), mpMap(map)
+{
+    setupUi(this);
+    areaTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    areaTable->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    setWindowTitle(tr("Configure Areas"));
+    resize(400, 300);
+
+    areaTable->setColumnCount(ColCount);
+    areaTable->setColumnHidden(ColAreaId, true);
+
+    areaTable->setHorizontalHeaderLabels({tr("Area Name"), QString(), tr("Rooms")});
+
+    connect(addAreaBtn, &QPushButton::clicked, this, &dlgConfigureAreas::slot_addArea);
+    connect(removeAreaBtn, &QPushButton::clicked, this, &dlgConfigureAreas::slot_removeArea);
+
+    populateAreaList();
+}
+
+bool checkDefaultArea(TMap* map, int areaId)
+{
+    if (!map || !map->mpRoomDB) 
+    {
+        return false;
+    }
+
+    const QString defaultAreaName = map->getDefaultAreaName();
+    const auto& areaNames = map->mpRoomDB->getAreaNamesMap();
+
+    return areaNames.value(areaId) == defaultAreaName;
+}
+
+int dlgConfigureAreas::currentAreaId() const
+{
+    const auto selected = areaTable->selectionModel()->selectedRows();
+    if (selected.isEmpty()) 
+    {
+        return -1;
+    }
+
+    return areaTable->item(selected.first().row(), ColAreaId)->text().toInt();
+}
+
+void dlgConfigureAreas::refreshAreas()
+{
+    QWidget* p = parentWidget();
+    while (p) 
+    {
+        const auto mappers = p->findChildren<dlgMapper*>();
+        for (dlgMapper* mapper : mappers) 
+        {
+            mapper->updateAreaComboBox();
+        }
+        p = p->parentWidget();
+    }
+}
+
+void dlgConfigureAreas::populateAreaList()
+{
+    if (!mpMap || !mpMap->mpRoomDB) 
+    {
+        return;
+    }
+
+    areaTable->setRowCount(0);
+
+    const auto& areaNames = mpMap->mpRoomDB->getAreaNamesMap();
+
+    int row = 0;
+    for (auto it = areaNames.begin(); it != areaNames.end(); ++it) 
+    {
+        const int areaId = it.key();
+        const QString& areaName = it.value();
+
+        int roomCount = 0;
+        if (TArea* area = mpMap->mpRoomDB->getArea(areaId)) 
+        {
+            roomCount = area->getAreaRooms().size();
+        }
+
+        areaTable->insertRow(row);
+        areaTable->setItem(row, ColAreaName, new QTableWidgetItem(areaName));
+        areaTable->setItem(row, ColAreaId, new QTableWidgetItem(QString::number(areaId)));
+        areaTable->setItem(row, ColRoomCount, new QTableWidgetItem(QString::number(roomCount)));
+        ++row;
+    }
+
+    areaTable->resizeColumnsToContents();
+}
+
+void dlgConfigureAreas::slot_addArea()
+{
+    if (!mpMap || !mpMap->mpRoomDB)
+    {
+        return;
+    }
+
+    bool ok{};
+    const QString name = QInputDialog::getText(this, tr("Add Area:"), tr("Area Name"), QLineEdit::Normal, QString(), &ok);
+
+    if (!ok || name.trimmed().isEmpty()) 
+    {
+        return;
+    }
+
+    const int newId = mpMap->mpRoomDB->addArea(name);
+    if (newId <= 0) 
+    {
+        QMessageBox::warning(this, tr("Cannot add area"), tr("Area with this name already exists."));
+        return;
+    }
+
+    populateAreaList();
+    refreshAreas();
+}
+
+void dlgConfigureAreas::slot_removeArea()
+{
+    if (!mpMap || !mpMap->mpRoomDB) 
+    {
+        return;
+    }
+
+    const int areaId = currentAreaId();
+    if (areaId <= 0) 
+    {
+        return;
+    }
+
+    if (checkDefaultArea(mpMap, areaId)) 
+    {
+        QMessageBox::warning(this, tr("Cannot delete area"), tr("Default area cannot be deleted."));
+        return;
+    }
+
+    TArea* area = mpMap->mpRoomDB->getArea(areaId);
+    const int roomCount = area ? area->getAreaRooms().size() : 0;
+
+    if (roomCount > 0) 
+    {
+        QMessageBox::warning(this, tr("Cannot delete area"), tr("This area contains %1 rooms.\n"
+               "Move or delete the rooms first.").arg(roomCount));
+        return;
+    }
+
+    const QString areaName = mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
+
+    const auto ret = QMessageBox::warning(this, tr("Delete Area"), tr("Delete empty area \"%1\"?").arg(areaName),
+                                        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
+
+    if (ret != QMessageBox::Yes) 
+    {
+        return;
+    }
+
+    mpMap->mpRoomDB->removeArea(areaId);
+
+    populateAreaList();
+    refreshAreas();
+}

--- a/src/dlgConfigureAreas.h
+++ b/src/dlgConfigureAreas.h
@@ -36,7 +36,7 @@ public slots:
 
 private:
     void populateAreaList();
-    void refreshAreas();
+    void refreshAreas(bool added, const QString& areaName);
     int currentAreaId() const;
 
     TMap* mpMap = nullptr;

--- a/src/dlgConfigureAreas.h
+++ b/src/dlgConfigureAreas.h
@@ -1,0 +1,45 @@
+#ifndef MUDLET_DLGCONFIGUREAREAS_H
+#define MUDLET_DLGCONFIGUREAREAS_H
+
+/***************************************************************************
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "ui_configure_areas.h"
+#include <QDialog>
+
+class TMap;
+
+class dlgConfigureAreas : public QDialog, public Ui::configure_areas
+{
+    Q_OBJECT
+
+public:
+    dlgConfigureAreas(TMap* map, QWidget* parent = nullptr);
+
+public slots:
+    void slot_addArea();
+    void slot_removeArea();
+
+private:
+    void populateAreaList();
+    void refreshAreas();
+    int currentAreaId() const;
+
+    TMap* mpMap = nullptr;
+};
+
+#endif //MUDLET_DLGCONFIGUREAREAS_H

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -598,6 +598,11 @@ void dlgMapper::slot_setupMapperMenu()
     menu->addAction(show3DMapAction);
 #endif
 
+    menu->addSeparator();
+    auto* newAreaConfigurator = new QAction(tr("Configure areas"), this);
+    connect(newAreaConfigurator, &QAction::triggered, mudlet::self(), &mudlet::slot_newAreaConfigurator);
+    menu->addAction(newAreaConfigurator);
+
     // Add separator and Info submenu
     menu->addSeparator();
     mpInfoMenu = menu->addMenu(tr("Info overlays"));

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -50,6 +50,7 @@
 #include "TToolBar.h"
 #include "XMLimport.h"
 #include "dlgAboutDialog.h"
+#include "dlgConfigureAreas.h"
 #include "dlgConnectionProfiles.h"
 #include "dlgIRC.h"
 #include "dlgMapper.h"
@@ -1765,6 +1766,19 @@ void mudlet::slot_newMapWindow()
     if (viewId == 0) {
         qWarning() << "mudlet::slot_newMapWindow() - failed to create map view:" << errorMsg;
     }
+}
+
+void mudlet::slot_newAreaConfigurator()
+{
+    Host* pHost = getActiveHost();
+    if (!pHost || !pHost->mpMap) 
+    {
+        return;
+    }
+
+    auto* dlg = new dlgConfigureAreas(pHost->mpMap.data(), this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->show();
 }
 
 void mudlet::updateWindowMenu()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1771,8 +1771,7 @@ void mudlet::slot_newMapWindow()
 void mudlet::slot_newAreaConfigurator()
 {
     Host* pHost = getActiveHost();
-    if (!pHost || !pHost->mpMap) 
-    {
+    if (!pHost || !pHost->mpMap) {
         return;
     }
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -437,6 +437,7 @@ public slots:
     void slot_toggleAlwaysOnTop();
     void slot_minimize();
     void slot_newMapWindow();
+    void slot_newAreaConfigurator();
     void updateWindowMenu();
     void slot_activateMainWindow();
     void slot_activateDetachedWindow();

--- a/src/ui/configure_areas.ui
+++ b/src/ui/configure_areas.ui
@@ -2,68 +2,78 @@
 <ui version="4.0">
  <class>configure_areas</class>
  <widget class="QDialog" name="configure_areas">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>400</width>
-    <height>300</height>
-   </rect>
-  </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Configure Areas</string>
   </property>
-  <widget class="QTableWidget" name="areaTable">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>381</width>
-     <height>192</height>
-    </rect>
-   </property>
-   <row>
-    <property name="text">
-     <string/>
-    </property>
-   </row>
-   <column>
-    <property name="text">
-     <string>Area Name</string>
-    </property>
-   </column>
-   <column>
-    <property name="text">
-     <string>Rooms</string>
-    </property>
-   </column>
-  </widget>
-  <widget class="QPushButton" name="addAreaBtn">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>240</y>
-     <width>93</width>
-     <height>26</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Add Area</string>
-   </property>
-  </widget>
-  <widget class="QPushButton" name="removeAreaBtn">
-   <property name="geometry">
-    <rect>
-     <x>110</x>
-     <y>240</y>
-     <width>93</width>
-     <height>26</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Remove Area</string>
-   </property>
-  </widget>
+
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
+
+   <item>
+    <widget class="QTableWidget" name="areaTable">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding"/>
+     </property>
+     <column>
+      <property name="text">
+       <string>Area Name</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Rooms</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+
+    <item>
+     <widget class="QLabel" name="statusLabel">
+      <property name = "text">
+       <string/>
+      </property>
+      <property name="styleSheet">
+       <string>color: red;</string>
+      </property>
+     </widget>
+    </item>
+
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+
+     <item>
+      <widget class="QPushButton" name="addAreaBtn">
+       <property name="text">
+        <string>Add Area</string>
+       </property>
+      </widget>
+     </item>
+
+     <item>
+      <widget class="QPushButton" name="removeAreaBtn">
+       <property name="text">
+        <string>Remove Area</string>
+       </property>
+      </widget>
+     </item>
+
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+
+    </layout>
+   </item>
+
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/src/ui/configure_areas.ui
+++ b/src/ui/configure_areas.ui
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>configure_areas</class>
+ <widget class="QDialog" name="configure_areas">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QTableWidget" name="areaTable">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>381</width>
+     <height>192</height>
+    </rect>
+   </property>
+   <row>
+    <property name="text">
+     <string/>
+    </property>
+   </row>
+   <column>
+    <property name="text">
+     <string>Area Name</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Rooms</string>
+    </property>
+   </column>
+  </widget>
+  <widget class="QPushButton" name="addAreaBtn">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>240</y>
+     <width>93</width>
+     <height>26</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Add Area</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="removeAreaBtn">
+   <property name="geometry">
+    <rect>
+     <x>110</x>
+     <y>240</y>
+     <width>93</width>
+     <height>26</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Remove Area</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Adds architecture to easily allow adding and deleting new areas via GUI.
- Includes some checks to not accidentally delete default area.

#### Motivation for adding to Mudlet
- Make it easier to handle areas similar to rooms.

#### Other info (issues closed, discussion etc)
Attempts to close #8 